### PR TITLE
feat: support python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: python:3.9.22
+      image: python:3.12.5
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: python:3.9.22
+      image: python:3.12.5
     needs: build
     steps:
       - uses: actions/checkout@v3

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -21,5 +21,4 @@ torch==2.3.1
 trafilatura==2.0.0
 unstructured==0.17.2
 wheel==0.42
-wheel==0.42
 wikipedia==1.4.0


### PR DESCRIPTION
Officially support Python 3.12.
This published package will be used in marketplace images (Ubuntu & Redhat) where Python3.12 is installed